### PR TITLE
fix: use correct cache path for Yarn and use frozen lockfile for install

### DIFF
--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: |
-          ~/.yarn/cache
+          client/.yarn/cache
           client/node_modules
         key: ${{ runner.os }}-yarn-${{ hashFiles('client/yarn.lock') }}
         restore-keys: |
@@ -40,7 +40,7 @@ jobs:
         node-version: '22'
 
     - name: Install dependencies
-      run: yarn install
+      run: yarn install --frozen-lockfile
       working-directory: client
 
     - name: Run TypeScript linter


### PR DESCRIPTION
Creating separate branch for testing CI workflows