### PR TITLE
fix: Update go version to 1.22 to match go.mod

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.18'
+        go-version: '1.22'
 
     - name: Cache Go modules
       uses: actions/cache@v4


### PR DESCRIPTION
This branch aims to fix the error in the server CI workflow where `go mod tidy` fails due to the step naming go v1.18 when the project uses v1.22